### PR TITLE
Do not count REDIRECT status as paid invoice

### DIFF
--- a/Plugin/Sales/Operation/EnforcePendingInvoice.php
+++ b/Plugin/Sales/Operation/EnforcePendingInvoice.php
@@ -31,7 +31,7 @@ class EnforcePendingInvoice
             $invoice = $result->getCreatedInvoice();
         }
 
-        if ($result->getAdditionalInformation(Config::PAYMENT_STATUS_KEY) === StatusInterface::CAPTURE_REQUESTED
+        if ($this->isNotPaidInvoice($result)
             && $result->getAdditionalInformation(Config::PRODUCT_PAYMENT_METHOD_KEY) === 'card'
         ) {
             /**
@@ -46,5 +46,19 @@ class EnforcePendingInvoice
         }
 
         return $result;
+    }
+
+    /**
+     * Checks if invoice is actually paid on Ingenico side by payment status from response object
+     *
+     * @param OrderPaymentInterface|Payment $payment
+     * @return bool
+     */
+    protected function isNotPaidInvoice(OrderPaymentInterface $result)
+    {
+        return in_array(
+            $result->getAdditionalInformation(Config::PAYMENT_STATUS_KEY),
+            [StatusInterface::CAPTURE_REQUESTED, StatusInterface::REDIRECTED]
+        );
     }
 }


### PR DESCRIPTION
Without this fix:
 - a POST request is sent to /payments
 - the response contains status = "REDIRECTED" (because the user needs to be
 redirected to complete the 3D Secure auth)
 - a new invoice is created and its status is **paid**

So the user actually hasn't paid, but in Magento, the order is counted as
paid. This fix makes sure when a user is REDIRECTED, the invoice does not have
status "PAID".