### PR TITLE
Solve compatibility issue with connect-sdk-php v6.46.0

### DIFF
--- a/Model/Worldline/Client/Communicator.php
+++ b/Model/Worldline/Client/Communicator.php
@@ -10,6 +10,7 @@ use Ingenico\Connect\Sdk\CommunicatorConfiguration;
 use Ingenico\Connect\Sdk\Connection;
 use Ingenico\Connect\Sdk\RequestObject;
 use Ingenico\Connect\Sdk\ResponseClassMap;
+use Ingenico\Connect\Sdk\ResponseExceptionFactory;
 use Psr\Log\LoggerInterface;
 
 // phpcs:ignore SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName
@@ -46,7 +47,9 @@ class Communicator extends \Ingenico\Connect\Sdk\Communicator
         // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
         RequestObject $requestParameters = null,
         // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
-        CallContext $callContext = null
+        CallContext $callContext = null,
+        // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
+        ResponseExceptionFactory $responseExceptionFactory = null
     ) {
         try {
             // phpcs:ignore SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName
@@ -68,7 +71,9 @@ class Communicator extends \Ingenico\Connect\Sdk\Communicator
         // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
         RequestObject $requestParameters = null,
         // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
-        CallContext $callContext = null
+        CallContext $callContext = null,
+        // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
+        ResponseExceptionFactory $responseExceptionFactory = null
     ) {
         try {
             // phpcs:ignore SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName
@@ -91,7 +96,9 @@ class Communicator extends \Ingenico\Connect\Sdk\Communicator
         // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
         RequestObject $requestParameters = null,
         // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
-        CallContext $callContext = null
+        CallContext $callContext = null,
+        // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
+        ResponseExceptionFactory $responseExceptionFactory = null
     ) {
         try {
             // phpcs:ignore SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName
@@ -114,7 +121,9 @@ class Communicator extends \Ingenico\Connect\Sdk\Communicator
         // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
         RequestObject $requestParameters = null,
         // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
-        CallContext $callContext = null
+        CallContext $callContext = null,
+        // phpcs:ignore SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing
+        ResponseExceptionFactory $responseExceptionFactory = null
     ) {
         try {
             // phpcs:ignore SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName


### PR DESCRIPTION
Without this update you will get the following errors on installing this module for Magento. 

```
PHP Fatal error:  Declaration of Worldline\Connect\Model\Worldline\Client\Communicator::get(Ingenico\Connect\Sdk\ResponseClassMap $responseClassMap, $relativeUriPath, $clientMetaInfo = '', ?Ingenico\Connect\Sdk\RequestObject $requestParameters = null, ?Ingenico\Connect\Sdk\CallContext $callContext = null) must be compatible with Ingenico\Connect\Sdk\Communicator::get(Ingenico\Connect\Sdk\ResponseClassMap $responseClassMap, $relativeUriPath, $clientMetaInfo = '', ?Ingenico\Connect\Sdk\RequestObject $requestParameters = null, ?Ingenico\Connect\Sdk\CallContext $callContext = null, ?Ingenico\Connect\Sdk\ResponseExceptionFactory $responseExceptionFactory = null) in /Users/kayintveen/Sites/bostontrader/vendor/ingenico-epayments/connect-extension-magento2/Model/Worldline/Client/Communicator.php on line 42
```

This is due to the update on https://github.com/Ingenico-ePayments/connect-sdk-php/commit/ef1ac4e2f9bec44a91bd1e3c03b35b7f13782b70
v6.46.0 on `Ingenico-ePayments/connect-sdk-php`